### PR TITLE
changed entrypoint to exec format

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -49,7 +49,7 @@ ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 
 EXPOSE 9998
-ENTRYPOINT java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0
+ENTRYPOINT ["java", "-jar", "/tika-server-${TIKA_VERSION}.jar", "-h", "0.0.0.0"]
 
 LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -49,7 +49,7 @@ ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 
 EXPOSE 9998
-ENTRYPOINT ["java", "-jar", "/tika-server-${TIKA_VERSION}.jar", "-h", "0.0.0.0"]
+ENTRYPOINT [ "/bin/sh", "-c", "exec java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0 $0 $@"]
 
 LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -45,6 +45,6 @@ ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 
 EXPOSE 9998
-ENTRYPOINT ["java", "-jar", "/tika-server-${TIKA_VERSION}.jar", "-h", "0.0.0.0"]
+ENTRYPOINT [ "/bin/sh", "-c", "exec java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0 $0 $@"]
 
 LABEL maintainer="Apache Tika Developers dev@tika.apache.org"

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -45,6 +45,6 @@ ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 
 EXPOSE 9998
-ENTRYPOINT java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0
+ENTRYPOINT ["java", "-jar", "/tika-server-${TIKA_VERSION}.jar", "-h", "0.0.0.0"]
 
 LABEL maintainer="Apache Tika Developers dev@tika.apache.org"


### PR DESCRIPTION
this also enables people to specify additional params, which is not possible in the current form:
https://docs.docker.com/engine/reference/builder/#entrypoint

> The shell form prevents any CMD or run command line arguments from being used, but has the disadvantage that your ENTRYPOINT will be started as a subcommand of /bin/sh -c, which does not pass signals. This means that the executable will not be the container’s PID 1 - and will not receive Unix signals - so your executable will not receive a SIGTERM from docker stop <container>.